### PR TITLE
feat: create-custom-paginate-header

### DIFF
--- a/src/app/shared/contracts/custom-header-listing.contract.ts
+++ b/src/app/shared/contracts/custom-header-listing.contract.ts
@@ -15,3 +15,20 @@ export class CustomHeaderListing<T> {
         this.size = paginate.size;
     }
 }
+
+export class CustomPaginateHeader<T> extends CustomHeaderListing<T> {
+    
+        @ApiProperty()
+        page: number;
+
+        @ApiProperty()
+        final_page: number;
+    
+        constructor(
+            paginate: CustomPaginateHeader<T>
+        ){
+            super(paginate);
+            this.page = paginate.page;
+            this.final_page = paginate.final_page;
+        }
+}


### PR DESCRIPTION
This pull request introduces a new class `CustomPaginateHeader` that extends `CustomHeaderListing` in the `src/app/shared/contracts/custom-header-listing.contract.ts` file. The new class includes additional properties and a constructor to initialize these properties.

Key changes:

* [`src/app/shared/contracts/custom-header-listing.contract.ts`](diffhunk://#diff-3e1870d78281c57ecc7264c3737d64b29202e84880c6c37ac76b9cffefbba2ecR18-R34): Added the `CustomPaginateHeader` class, which extends `CustomHeaderListing` and includes `page` and `final_page` properties annotated with `@ApiProperty`. The constructor initializes these properties.