### PR TITLE
Feat/convert enum problemtype to number

### DIFF
--- a/src/app/modules/problems/dto/get-problem.dto.ts
+++ b/src/app/modules/problems/dto/get-problem.dto.ts
@@ -1,22 +1,29 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { IsNumber, IsString } from "class-validator";
 
 export class GetProblemDto {
     @ApiProperty()
+    @IsString()
     name: string;
 
     @ApiProperty()
+    @IsString()
     address: string;
 
     @ApiProperty()
+    @IsString()
     description: string;
 
     @ApiProperty()
+    @IsNumber()
     latitude: number;
 
     @ApiProperty()
+    @IsNumber()
     longitude: number;
 
     @ApiProperty()
+    @IsString()
     photo: string;
 
     @ApiProperty({ enum: [1, 2, 3, 4, 5] })

--- a/src/app/modules/problems/dto/get-problem.dto.ts
+++ b/src/app/modules/problems/dto/get-problem.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class GetProblemDto {
+    @ApiProperty()
+    name: string;
+
+    @ApiProperty()
+    address: string;
+
+    @ApiProperty()
+    description: string;
+
+    @ApiProperty()
+    latitude: number;
+
+    @ApiProperty()
+    longitude: number;
+
+    @ApiProperty()
+    photo: string;
+
+    @ApiProperty({ enum: [1, 2, 3, 4, 5] })
+    problemType: number;
+}

--- a/src/app/modules/problems/dto/save-problem.dto.ts
+++ b/src/app/modules/problems/dto/save-problem.dto.ts
@@ -29,7 +29,7 @@ export class SaveProblemDto {
     @IsString()
     photo: string
 
-    @ApiProperty()
-    @IsEnum(PROBLEM_TYPE)
-    problemType: PROBLEM_TYPE
+    @ApiProperty({ enum: [1, 2, 3, 4, 5] })
+    @IsNumber()
+    problemType: number;
 }

--- a/src/app/modules/problems/dto/update-problem-dto.ts
+++ b/src/app/modules/problems/dto/update-problem-dto.ts
@@ -29,9 +29,9 @@ export class UpdateProblemDto{
     @IsString()
     photo: string
 
-    @ApiProperty()
-    @IsEnum(PROBLEM_TYPE)
-    problemType: PROBLEM_TYPE
+    @ApiProperty({ enum: [1, 2, 3, 4, 5] })
+    @IsNumber()
+    problemType: number;
 }
 
 

--- a/src/app/modules/problems/serializers/problems.serializers.ts
+++ b/src/app/modules/problems/serializers/problems.serializers.ts
@@ -53,7 +53,7 @@ export class ProblemSerializer {
             latitude: input.getLatitude(),
             longitude: input.getLongitude(),
             photo: input.getPhoto(),
-            problemType: ProblemSerializer.mapProblemTypeToNumber(input.getProblemType()), // Chame o método estático pela classe
+            problemType: ProblemSerializer.mapProblemTypeToNumber(input.getProblemType()), 
         };
     }
 

--- a/src/app/modules/problems/serializers/problems.serializers.ts
+++ b/src/app/modules/problems/serializers/problems.serializers.ts
@@ -1,8 +1,21 @@
+import { PROBLEM_TYPE } from "@prisma/client";
 import { SaveProblemDto } from "../dto/save-problem.dto";
 import { UpdateProblemUseCaseInputDto } from "../dto/update-problem-dto";
 import { ProblemEntity } from "../entities/problem.entity";
+import { GetProblemDto } from "../dto/get-problem.dto";
 
 export class ProblemSerializer {
+
+    static mapNumberToProblemType(num: number): PROBLEM_TYPE {
+        const values = Object.values(PROBLEM_TYPE);
+        return values[num - 1];
+    }
+
+    static mapProblemTypeToNumber(problemType: PROBLEM_TYPE): number {
+        const values = Object.values(PROBLEM_TYPE);
+        return values.indexOf(problemType) + 1;
+    }
+
     static transformToSaveProblem(input: SaveProblemDto) {
         const entity = new ProblemEntity();
         
@@ -12,7 +25,7 @@ export class ProblemSerializer {
         entity.setLatitude(input.latitude);
         entity.setLongitude(input.longitude);
         entity.setPhoto(input.photo);
-        entity.setProblemType(input.problemType);
+        entity.setProblemType(this.mapNumberToProblemType(input.problemType));
   
 
         return entity;
@@ -28,11 +41,11 @@ export class ProblemSerializer {
         entity.setLatitude(input.latitude);
         entity.setLongitude(input.longitude);
         entity.setPhoto(input.photo);
-        entity.setProblemType(input.problemType);
+        entity.setProblemType(this.mapNumberToProblemType(input.problemType));
         return entity;
     }
 
-    static transformToGetProblem(input: ProblemEntity){
+    static transformToGetProblem(input: ProblemEntity) {
         return {
             name: input.getName(),
             address: input.getAddress(),
@@ -40,9 +53,8 @@ export class ProblemSerializer {
             latitude: input.getLatitude(),
             longitude: input.getLongitude(),
             photo: input.getPhoto(),
-            problemType: input.getProblemType(),
-          
-        }
+            problemType: ProblemSerializer.mapProblemTypeToNumber(input.getProblemType()), // Chame o método estático pela classe
+        };
     }
 
     static transformToManyGetProblem(input: ProblemEntity[]){

--- a/src/infra/databases/orms/prisma/schema.prisma
+++ b/src/infra/databases/orms/prisma/schema.prisma
@@ -63,8 +63,9 @@ model Warning {
 enum PROBLEM_TYPE {
   LACK_OF_ENERGY
   SANITATION
-  HEALTH
+  INFRASTRUCTURE
   RISK_AREA
+  OTHERS
 }
 
 model Problems {


### PR DESCRIPTION
## Description
Altera o comportamento da API relacionada à criação e obtenção de problemas na tabela Problem. Agora, o campo problemType é enviado e recebido como uma posição numérica, em vez de uma string com os valores do enum (LACK_OF_ENERGY, SANITATION, etc.). Foi feita a conversão no backend para garantir que o front-end envie um número e o backend o converta para o valor correto do enum e também retorna para o front como um número. 

## Task
[CTY-005][BACK] - Ajustar inserção do tipo ENUM na tabela problemas

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

As mudanças foram testadas manualmente no insomnia para garantir que:

O front-end pode enviar a posição numérica do problemType corretamente.
A API processa e armazena o valor correto do enum no banco de dados.
As respostas da API enviam a posição numérica do problemType de volta ao front-end.
