### PR TITLE
Feat/add UUID problems

### DIFF
--- a/src/app/modules/problems/controllers/problem.controller.ts
+++ b/src/app/modules/problems/controllers/problem.controller.ts
@@ -22,14 +22,14 @@ export class ProblemController {
     @Get()
     @HttpCode(HttpStatus.OK)
     @UseGuards(AuthGuard)
-    async fetchLocalization(){
+    async fetchProblem(){
         return this.getProblemUseCase.execute()
     }
 
     @Post()
     @UseGuards(AuthGuard)
     @HttpCode(HttpStatus.OK)
-    async location(@Body() body: SaveProblemDto): Promise<void> {
+    async problem(@Body() body: SaveProblemDto): Promise<void> {
         return this.saveProblemUsecase.execute(body);
     }
 
@@ -40,7 +40,7 @@ export class ProblemController {
         required: true,
         type: Number
     })
-    async deleteLocalization(
+    async deleteProblem(
         @Param('id', ParseIntPipe) id: number,     
     ): Promise<void> {
         return this.deleteProblemUseCase.execute({
@@ -56,7 +56,7 @@ export class ProblemController {
         type: Number
     })
     @HttpCode(HttpStatus.OK)
-    async updateLocation(
+    async updateProblem(
         @Body() body: UpdateProblemDto,
         @Param('id', ParseIntPipe) param: number,
     ): Promise<void> {

--- a/src/infra/databases/orms/prisma/migrations/20241108015101_add_uuid_to_problems/migration.sql
+++ b/src/infra/databases/orms/prisma/migrations/20241108015101_add_uuid_to_problems/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The values [HEALTH] on the enum `PROBLEM_TYPE` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "PROBLEM_TYPE_new" AS ENUM ('LACK_OF_ENERGY', 'SANITATION', 'INFRASTRUCTURE', 'RISK_AREA', 'OTHERS');
+ALTER TABLE "problems" ALTER COLUMN "problem_type" TYPE "PROBLEM_TYPE_new" USING ("problem_type"::text::"PROBLEM_TYPE_new");
+ALTER TYPE "PROBLEM_TYPE" RENAME TO "PROBLEM_TYPE_old";
+ALTER TYPE "PROBLEM_TYPE_new" RENAME TO "PROBLEM_TYPE";
+DROP TYPE "PROBLEM_TYPE_old";
+COMMIT;

--- a/src/infra/databases/orms/prisma/migrations/20241108015935_add_uuid_to_problems/migration.sql
+++ b/src/infra/databases/orms/prisma/migrations/20241108015935_add_uuid_to_problems/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[uuid]` on the table `problems` will be added. If there are existing duplicate values, this will fail.
+  - The required column `uuid` was added to the `problems` table with a prisma-level default value. This is not possible if the table is not empty. Please add this column as optional, then populate it before making it required.
+
+*/
+-- AlterTable
+ALTER TABLE "problems" ADD COLUMN     "uuid" UUID NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "problems_uuid_key" ON "problems"("uuid");

--- a/src/infra/databases/orms/prisma/schema.prisma
+++ b/src/infra/databases/orms/prisma/schema.prisma
@@ -70,6 +70,7 @@ enum PROBLEM_TYPE {
 
 model Problems {
   id          Int     @id @default(autoincrement())
+  uuid        String  @unique() @default(uuid()) @db.Uuid()
   name        String  @db.VarChar(50)
   address     String  @db.VarChar(255)
   description String  @db.VarChar(255)


### PR DESCRIPTION
## Description
Adicionei o campo uuid à tabela Problems para fornecer um identificador único a cada registro, facilitando operações futuras de CRUD. Rodado a migration para refletir as mudanças no banco de dados. Atualizado o problem.entity com o uuid.

## Task
[CTY-005][BACK] Adicionar o uuid do problema

## Type of change

- [X] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
Validado que o campo uuid foi adicionado ao modelo Problems e aparece no banco de dados após a migration.